### PR TITLE
Don't include the test suite in code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,6 @@
+[run]
+omit = epiphany/test/*
+
 [report]
 # Regexes for lines to exclude from consideration
 exclude_lines =

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,9 @@ install:
     - export PYTHONPATH=${PYTHONPATH}:${HOME}/pydgin/:${HOME}/pypy
 
 script:
-    - py.test -n 4 --cov-report term-missing --cov epiphany epiphany/test/
+    - py.test -n 4 --cov-config .coveragerc
+                   --cov-report term-missing
+                   --cov=epiphany epiphany/test/
     - python -m doctest scripts/diff_trace.py
     - test "$TRANSLATE" == "true" && ${HOME}/pypy/rpython/bin/rpython --opt=jit epiphany/sim.py || true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 coveralls
-pytest-cov
+pytest-cov>=2.0.0
 pytest-xdist


### PR DESCRIPTION
Feel free to ignore/reject this. It's a matter of personal taste, and `pytest>=2.0.0` moves you further away from being able to use PyPy's bundled pytest